### PR TITLE
feat: don't block event loop

### DIFF
--- a/userscript/src/components/Parent.ts
+++ b/userscript/src/components/Parent.ts
@@ -149,13 +149,11 @@ export class Parent {
         );
 
         // 順位表のその他の描画を優先するために，プロットは後回しにする
-        window.setTimeout((): void => {
-            void charts.plotAsync().then(() => {
-                charts.hideLoader();
-                tabs.showTabsControl();
-                this.working = false;
-            });
-        }, 100);
+        charts.plotAsync().then(() => {
+            charts.hideLoader();
+            tabs.showTabsControl();
+            this.working = false;
+        });
     }
 
     removeOldContents(): void {


### PR DESCRIPTION
ABCなどでグラフ描画処理中に他のuserscriptの実行や順位表のページ遷移などができなかったため、
重い部分に定期的にevent loopに処理を譲る処理を追加しました。
もしよろしければmergeをお願いします。
手元でABC249を例に確認したときは変更前は9.610sで変更後は10.885sとイベントループに処理を譲る関係上描画はすこしおそくなりました。